### PR TITLE
add macros for instanciate input and output signals for AXI4-full protocol

### DIFF
--- a/hardware/include/axi.vh
+++ b/hardware/include/axi.vh
@@ -1,3 +1,7 @@
+//
+// Signals width
+//
+
 // Address width
 `define AXI_ADDR_W 32
 
@@ -27,3 +31,109 @@
 
 // Response width (response = 0 - Okay = 0; Exokay = 1; Slverr = 2; decerr = 3)
 `define AXI_RESP_W 2
+
+//
+// Signals declaration
+//
+
+// Port
+
+`define AXI4_M_IF_PORT_PREFIX(PREFIX) \
+    /*address write*/ \
+    output [`AXI_ID_W-1:0]    PREFIX``m_axi_awid,    /*Address write channel ID*/ \
+    output [AXI_ADDR_W-1:0]   PREFIX``m_axi_awaddr,  /*Address write channel address*/ \
+    output [`AXI_LEN_W-1:0]   PREFIX``m_axi_awlen,   /*Address write channel burst length*/ \
+    output [`AXI_SIZE_W-1:0]  PREFIX``m_axi_awsize,  /*Address write channel burst size. This signal indicates the size of each transfer in the burst*/ \
+    output [`AXI_BURST_W-1:0] PREFIX``m_axi_awburst, /*Address write channel burst type*/ \
+    output [`AXI_LOCK_W-1:0]  PREFIX``m_axi_awlock,  /*Address write channel lock type*/ \
+    output [`AXI_CACHE_W-1:0] PREFIX``m_axi_awcache, /*Address write channel memory type. Transactions set with Normal Non-cacheable Modifiable and Bufferable (0011).*/ \
+    output [`AXI_PROT_W-1:0]  PREFIX``m_axi_awprot,  /*Address write channel protection type. Transactions set with Normal, Secure, and Data attributes (000).*/ \
+    output [`AXI_QOS_W-1:0]   PREFIX``m_axi_awqos,   /*Address write channel quality of service*/ \
+    output                    PREFIX``m_axi_awvalid, /*Address write channel valid*/ \
+    input                     PREFIX``m_axi_awready, /*Address write channel ready*/ \
+    /*write*/ \
+    output [AXI_DATA_W-1:0]   PREFIX``m_axi_wdata,   /*Write channel data*/ \
+    output [AXI_DATA_W/8-1:0] PREFIX``m_axi_wstrb,   /*Write channel write strobe*/ \
+    output                    PREFIX``m_axi_wlast,   /*Write channel last word flag*/ \
+    output                    PREFIX``m_axi_wvalid,  /*Write channel valid*/ \
+    input                     PREFIX``m_axi_wready,  /*Write channel ready*/ \
+    /*write response*/ \
+    input [`AXI_ID_W-1:0]     PREFIX``m_axi_bid,     /*Write response channel ID*/ \
+    input [`AXI_RESP_W-1:0]   PREFIX``m_axi_bresp,   /*Write response channel response*/ \
+    input                     PREFIX``m_axi_bvalid,  /*Write response channel valid*/ \
+    output                    PREFIX``m_axi_bready,  /*Write response channel ready*/ \
+    /*address read*/ \
+    output [`AXI_ID_W-1:0]    PREFIX``m_axi_arid,    /*Address read channel id*/ \
+    output [AXI_ADDR_W-1:0]   PREFIX``m_axi_araddr,  /*Address read channel address*/ \
+    output [`AXI_LEN_W-1:0]   PREFIX``m_axi_arlen,   /*Address read channel burst length*/ \
+    output [`AXI_SIZE_W-1:0]  PREFIX``m_axi_arsize,  /*Address read channel burst size. This signal indicates the size of each transfer in the burst*/ \
+    output [`AXI_BURST_W-1:0] PREFIX``m_axi_arburst, /*Address read channel burst type*/ \
+    output [`AXI_PROT_W-1:0]  PREFIX``m_axi_arlock,  /*Address read channel lock type*/ \
+    output [`AXI_CACHE_W-1:0] PREFIX``m_axi_arcache, /*Address read channel memory type. Transactions set with Normal Non-cacheable Modifiable and Bufferable (0011).*/ \
+    output [`AXI_PROT_W-1:0]  PREFIX``m_axi_arprot,  /*Address read channel protection type. Transactions set with Normal, Secure, and Data attributes (000).*/ \
+    output [`AXI_QOS_W-1:0]   PREFIX``m_axi_arqos,   /*Address read channel quality of service*/ \
+    output                    PREFIX``m_axi_arvalid, /*Address read channel valid*/ \
+    input                     PREFIX``m_axi_arready, /*Address read channel ready*/ \
+    /*read*/ \
+    input [`AXI_ID_W-1:0]     PREFIX``m_axi_rid,     /*Read channel ID*/ \
+    input [AXI_DATA_W-1:0]    PREFIX``m_axi_rdata,   /*Read channel data*/ \
+    input [`AXI_RESP_W-1:0]   PREFIX``m_axi_rresp,   /*Read channel response*/ \
+    input                     PREFIX``m_axi_rlast,   /*Read channel last word*/ \
+    input                     PREFIX``m_axi_rvalid,  /*Read channel valid*/ \
+    output                    PREFIX``m_axi_rready   /*Read channel ready*/
+
+`define AXI4_S_IF_PORT_PREFIX(PREFIX) \
+    /*address write*/ \
+    input [`AXI_ID_W-1:0]     PREFIX``s_axi_awid,    /*Address write channel ID*/ \
+    input [AXI_ADDR_W-1:0]    PREFIX``s_axi_awaddr,  /*Address write channel address*/ \
+    input [`AXI_LEN_W-1:0]    PREFIX``s_axi_awlen,   /*Address write channel burst length*/ \
+    input [`AXI_SIZE_W-1:0]   PREFIX``s_axi_awsize,  /*Address write channel burst size. This signal indicates the size of each transfer in the burst*/ \
+    input [`AXI_BURST_W-1:0]  PREFIX``s_axi_awburst, /*Address write channel burst type*/ \
+    input [`AXI_LOCK_W-1:0]   PREFIX``s_axi_awlock,  /*Address write channel lock type*/ \
+    input [`AXI_CACHE_W-1:0]  PREFIX``s_axi_awcache, /*Address write channel memory type. Transactions set with Normal Non-cacheable Modifiable and Bufferable (0011).*/ \
+    input [`AXI_PROT_W-1:0]   PREFIX``s_axi_awprot,  /*Address write channel protection type. Transactions set with Normal, Secure, and Data attributes (000).*/ \
+    input [`AXI_QOS_W-1:0]    PREFIX``s_axi_awqos,   /*Address write channel quality of service*/ \
+    input                     PREFIX``s_axi_awvalid, /*Address write channel valid*/ \
+    output                    PREFIX``s_axi_awready, /*Address write channel ready*/ \
+    /*write*/ \
+    input [AXI_DATA_W-1:0]    PREFIX``s_axi_wdata,   /*Write channel data*/ \
+    input [AXI_DATA_W/8-1:0]  PREFIX``s_axi_wstrb,   /*Write channel write strobe*/ \
+    input                     PREFIX``s_axi_wlast,   /*Write channel last word flag*/ \
+    input                     PREFIX``s_axi_wvalid,  /*Write channel valid*/ \
+    output                    PREFIX``s_axi_wready,  /*Write channel ready*/ \
+    /*write response*/ \
+    output [`AXI_ID_W-1:0]    PREFIX``s_axi_bid,     /*Write response channel ID*/ \
+    output [`AXI_RESP_W-1:0]  PREFIX``s_axi_bresp,   /*Write response channel response*/ \
+    output                    PREFIX``s_axi_bvalid,  /*Write response channel valid*/ \
+    input                     PREFIX``s_axi_bready,  /*Write response channel ready*/ \
+    /*address read*/ \
+    input [`AXI_ID_W-1:0]     PREFIX``s_axi_arid,    /*Address read channel id*/ \
+    input [AXI_ADDR_W-1:0]    PREFIX``s_axi_araddr,  /*Address read channel address*/ \
+    input [`AXI_LEN_W-1:0]    PREFIX``s_axi_arlen,   /*Address read channel burst length*/ \
+    input [`AXI_SIZE_W-1:0]   PREFIX``s_axi_arsize,  /*Address read channel burst size. This signal indicates the size of each transfer in the burst*/ \
+    input [`AXI_BURST_W-1:0]  PREFIX``s_axi_arburst, /*Address read channel burst type*/ \
+    input [`AXI_PROT_W-1:0]   PREFIX``s_axi_arlock,  /*Address read channel lock type*/ \
+    input [`AXI_CACHE_W-1:0]  PREFIX``s_axi_arcache, /*Address read channel memory type. Transactions set with Normal Non-cacheable Modifiable and Bufferable (0011).*/ \
+    input [`AXI_PROT_W-1:0]   PREFIX``s_axi_arprot,  /*Address read channel protection type. Transactions set with Normal, Secure, and Data attributes (000).*/ \
+    input [`AXI_QOS_W-1:0]    PREFIX``s_axi_arqos,   /*Address read channel quality of service*/ \
+    input                     PREFIX``s_axi_arvalid, /*Address read channel valid*/ \
+    output                    PREFIX``s_axi_arready, /*Address read channel ready*/ \
+    /*read*/ \
+    output [`AXI_ID_W-1:0]    PREFIX``s_axi_rid,     /*Read channel ID*/ \
+    output [AXI_DATA_W-1:0]   PREFIX``s_axi_rdata,   /*Read channel data*/ \
+    output [`AXI_RESP_W-1:0]  PREFIX``s_axi_rresp,   /*Read channel response*/ \
+    output                    PREFIX``s_axi_rlast,   /*Read channel last word*/ \
+    output                    PREFIX``s_axi_rvalid,  /*Read channel valid*/ \
+    input                     PREFIX``s_axi_rready,  /*Read channel ready*/
+
+`define AXI4_M_IF_PORT_CORE(CORE) \
+    `AXI4_M_IF_PORT_PREFIX(CORE``_)
+
+`define AXI4_S_IF_PORT_CORE(CORE) \
+    `AXI4_S_IF_PORT_PREFIX(CORE``_)
+
+`define AXI4_M_IF_PORT \
+    `AXI4_M_IF_PORT_PREFIX()
+
+`define AXI4_S_IF_PORT \
+    `AXI4_S_IF_PORT_PREFIX()


### PR DESCRIPTION
The macros added are intended to instantiate the input and output signals for AXI4-full protocol as follows:

AXI4_M_IF_PORT and AXI4_S_IF_PORT macros instantiate all signals (for a master of a slave interface, depending on the M or the S). The master signals have the prefix m_ (ex.: m_axi_wdata), and the slave signals have the prefix s_ (ex.: s_axi_wdata).

AXI4_M_IF_PORT_CORE(CORE) and AXI4_S_IF_PORT_CORE(CORE) macros instantiate the same signals as explained above, but with the prefix CORE_. So, if the CORE is set to sys for instance, then the AXI4 signals have the prefix sys_ (ex.: sys_m_axi_wdata).

AXI4_M_IF_PORT_PREFIX(PREFIX) and AXI4_S_IF_PORT_PREFIX(PREFIX) macros are used to make the other four macros. Here the PREFIX is either set to CORE_ or blanc.